### PR TITLE
Feature implementation from commits 1b03920..5df9956

### DIFF
--- a/packages/ra-core/codemods/__testfixtures__/replace-Datagrid-DataTable-Basic.input.tsx
+++ b/packages/ra-core/codemods/__testfixtures__/replace-Datagrid-DataTable-Basic.input.tsx
@@ -1,0 +1,15 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import * as React from 'react';
+import { List, Datagrid, TextField } from 'react-admin';
+
+const PostList = () => (
+    <List>
+        <Datagrid>
+            <TextField source="id" label="Post number" />
+            <TextField source="title" />
+            <TextField source="body" />
+        </Datagrid>
+    </List>
+);
+
+export default PostList;

--- a/packages/ra-core/codemods/__testfixtures__/replace-Datagrid-DataTable-Basic.output.tsx
+++ b/packages/ra-core/codemods/__testfixtures__/replace-Datagrid-DataTable-Basic.output.tsx
@@ -1,0 +1,15 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import * as React from 'react';
+import { List, DataTable } from 'react-admin';
+
+const PostList = () => (
+    <List>
+        <DataTable>
+            <DataTable.Col source="id" label="Post number" />
+            <DataTable.Col source="title" />
+            <DataTable.Col source="body" />
+        </DataTable>
+    </List>
+);
+
+export default PostList;

--- a/packages/ra-core/codemods/__testfixtures__/replace-Datagrid-DataTable-ManyChildren.input.tsx
+++ b/packages/ra-core/codemods/__testfixtures__/replace-Datagrid-DataTable-ManyChildren.input.tsx
@@ -1,0 +1,36 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import * as React from 'react';
+import {
+    List,
+    Datagrid,
+    TextField,
+    EmailField,
+    NumberField,
+    EditButton,
+    ReferenceField,
+    UrlField,
+    DateField,
+} from 'react-admin';
+
+// @ts-ignore
+import { MyCustomField } from './MyCustomField';
+
+const PostList = () => (
+    <List>
+        <Datagrid>
+            <TextField source="id" />
+            <EmailField source="email" />
+            <NumberField source="nb_vues" />
+            <TextField source="title" />
+            <ReferenceField source="userId" reference="users">
+                <TextField source="name" />
+            </ReferenceField>
+            <UrlField source="url" />
+            <DateField source="createdAt" />
+            <MyCustomField source="code" />
+            <EditButton />
+        </Datagrid>
+    </List>
+);
+
+export default PostList;

--- a/packages/ra-core/codemods/__testfixtures__/replace-Datagrid-DataTable-ManyChildren.output.tsx
+++ b/packages/ra-core/codemods/__testfixtures__/replace-Datagrid-DataTable-ManyChildren.output.tsx
@@ -1,0 +1,37 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import * as React from 'react';
+import {
+    List,
+    DataTable,
+    TextField,
+    EmailField,
+    EditButton,
+    ReferenceField,
+    UrlField,
+    DateField,
+} from 'react-admin';
+
+// @ts-ignore
+import { MyCustomField } from './MyCustomField';
+
+const PostList = () => (
+    <List>
+        <DataTable>
+            <DataTable.Col source="id" />
+            <DataTable.Col source="email" field={EmailField} />
+            <DataTable.NumberCol source="nb_vues" />
+            <DataTable.Col source="title" />
+            <DataTable.Col source="userId">
+                <ReferenceField source="userId" reference="users">
+                    <TextField source="name" />
+                </ReferenceField>
+            </DataTable.Col>
+            <DataTable.Col source="url" field={UrlField} />
+            <DataTable.Col source="createdAt" field={DateField} />
+            <DataTable.Col source="code" field={MyCustomField} />
+            <EditButton />
+        </DataTable>
+    </List>
+);
+
+export default PostList;

--- a/packages/ra-core/codemods/__testfixtures__/replace-Datagrid-DataTable-ManyChildren.output.tsx
+++ b/packages/ra-core/codemods/__testfixtures__/replace-Datagrid-DataTable-ManyChildren.output.tsx
@@ -18,7 +18,9 @@ const PostList = () => (
     <List>
         <DataTable>
             <DataTable.Col source="id" />
-            <DataTable.Col source="email" field={EmailField} />
+            <DataTable.Col source="email">
+                <EmailField source="email" />
+            </DataTable.Col>
             <DataTable.NumberCol source="nb_vues" />
             <DataTable.Col source="title" />
             <DataTable.Col source="userId">
@@ -26,10 +28,18 @@ const PostList = () => (
                     <TextField source="name" />
                 </ReferenceField>
             </DataTable.Col>
-            <DataTable.Col source="url" field={UrlField} />
-            <DataTable.Col source="createdAt" field={DateField} />
-            <DataTable.Col source="code" field={MyCustomField} />
-            <EditButton />
+            <DataTable.Col source="url">
+                <UrlField source="url" />
+            </DataTable.Col>
+            <DataTable.Col source="createdAt">
+                <DateField source="createdAt" />
+            </DataTable.Col>
+            <DataTable.Col source="code">
+                <MyCustomField source="code" />
+            </DataTable.Col>
+            <DataTable.Col>
+                <EditButton />
+            </DataTable.Col>
         </DataTable>
     </List>
 );

--- a/packages/ra-core/codemods/__testfixtures__/replace-Datagrid-DataTable-Props.input.tsx
+++ b/packages/ra-core/codemods/__testfixtures__/replace-Datagrid-DataTable-Props.input.tsx
@@ -1,0 +1,42 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import * as React from 'react';
+import { List, Datagrid, TextField, useRecordContext } from 'react-admin';
+
+const CustomEmpty = () => <div>No posts found</div>;
+
+const PostPanel = () => {
+    const record = useRecordContext();
+    return <div dangerouslySetInnerHTML={{ __html: record.body }} />;
+};
+
+const postRowStyle = (record, index) => ({
+    backgroundColor: record.nb_views >= 500 ? '#efe' : 'white',
+});
+
+const PostList = () => (
+    <List>
+        <Datagrid
+            bulkActionButtons={false}
+            empty={<CustomEmpty />}
+            expand={<PostPanel />}
+            expandSingle
+            rowClick={false}
+            optimized
+            rowStyle={postRowStyle}
+            sx={{
+                '& .RaDatagrid-row': {
+                    backgroundColor: 'white',
+                },
+                '& .RaDatagrid-row:hover': {
+                    backgroundColor: '#f5f5f5',
+                },
+            }}
+        >
+            <TextField source="id" />
+            <TextField source="title" />
+            <TextField source="body" />
+        </Datagrid>
+    </List>
+);
+
+export default PostList;

--- a/packages/ra-core/codemods/__testfixtures__/replace-Datagrid-DataTable-Props.output.tsx
+++ b/packages/ra-core/codemods/__testfixtures__/replace-Datagrid-DataTable-Props.output.tsx
@@ -1,0 +1,41 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import * as React from 'react';
+import { List, DataTable, useRecordContext } from 'react-admin';
+
+const CustomEmpty = () => <div>No posts found</div>;
+
+const PostPanel = () => {
+    const record = useRecordContext();
+    return <div dangerouslySetInnerHTML={{ __html: record.body }} />;
+};
+
+const postRowStyle = (record, index) => ({
+    backgroundColor: record.nb_views >= 500 ? '#efe' : 'white',
+});
+
+const PostList = () => (
+    <List>
+        <DataTable
+            bulkActionButtons={false}
+            empty={<CustomEmpty />}
+            expand={<PostPanel />}
+            expandSingle
+            rowClick={false}
+            rowSx={postRowStyle}
+            sx={{
+                '& .RaDataTable-row': {
+                    backgroundColor: 'white',
+                },
+                '& .RaDataTable-row:hover': {
+                    backgroundColor: '#f5f5f5',
+                },
+            }}
+        >
+            <DataTable.Col source="id" />
+            <DataTable.Col source="title" />
+            <DataTable.Col source="body" />
+        </DataTable>
+    </List>
+);
+
+export default PostList;

--- a/packages/ra-core/codemods/__tests__/replace-Datagrid-DataTable.spec.ts
+++ b/packages/ra-core/codemods/__tests__/replace-Datagrid-DataTable.spec.ts
@@ -1,0 +1,25 @@
+import { defineTest } from 'jscodeshift/dist/testUtils';
+
+jest.autoMockOff();
+
+defineTest(
+    __dirname,
+    'replace-Datagrid-DataTable',
+    null,
+    'replace-Datagrid-DataTable-Basic',
+    { parser: 'tsx' }
+);
+defineTest(
+    __dirname,
+    'replace-Datagrid-DataTable',
+    null,
+    'replace-Datagrid-DataTable-ManyChildren',
+    { parser: 'tsx' }
+);
+defineTest(
+    __dirname,
+    'replace-Datagrid-DataTable',
+    null,
+    'replace-Datagrid-DataTable-Props',
+    { parser: 'tsx' }
+);

--- a/packages/ra-core/codemods/replace-Datagrid-DataTable.ts
+++ b/packages/ra-core/codemods/replace-Datagrid-DataTable.ts
@@ -80,9 +80,15 @@ const replaceDatagrid = (root, j) => {
 
     // Replace Datagrid with DataTable
     datagridComponents.replaceWith(({ node }) => {
+        // remove the `optimized` attribute if it exists
+        const attributes = node.openingElement.attributes.filter(
+            attr =>
+                !(j.JSXAttribute.check(attr) && attr.name.name === 'optimized')
+        );
+
         const openingElement = j.jsxOpeningElement(
             j.jsxIdentifier('DataTable'),
-            node.openingElement.attributes,
+            attributes,
             node.openingElement.selfClosing
         );
         const closingElement = j.jsxClosingElement(

--- a/packages/ra-core/codemods/replace-Datagrid-DataTable.ts
+++ b/packages/ra-core/codemods/replace-Datagrid-DataTable.ts
@@ -4,12 +4,20 @@ module.exports = (file, api: j.API) => {
     const j = api.jscodeshift;
     const root = j(file.source);
 
-    replaceImports(root, j);
+    const continueAfterImport = replaceImport(root, j);
+    if (!continueAfterImport) {
+        return root.toSource();
+    }
+
+    const continueAfterComponent = replaceComponent(root, j);
+    if (!continueAfterComponent) {
+        return root.toSource();
+    }
 
     return root.toSource({ quote: 'single', lineTerminator: '\n' });
 };
 
-const replaceImports = (root, j) => {
+const replaceImport = (root, j) => {
     // Check if there is an import from react-admin
     const reactAdminImport = root.find(j.ImportDeclaration, {
         source: {
@@ -17,7 +25,7 @@ const replaceImports = (root, j) => {
         },
     });
     if (!reactAdminImport.length) {
-        return root.toSource();
+        return false;
     }
 
     // Check if there is an import of DataGrid from react-admin
@@ -28,10 +36,8 @@ const replaceImports = (root, j) => {
                 specifier.imported.name === 'Datagrid'
         );
     });
-    console.log('toto - 4', datagridImport);
     if (!datagridImport.length) {
-        console.log('toto - 5 - OUT');
-        return root.toSource();
+        return false;
     }
 
     // Replace import of DataGrid with DataTable
@@ -49,4 +55,9 @@ const replaceImports = (root, j) => {
             node.source
         )
     );
+};
+
+const replaceComponent = (root, j) => {
+    // TODO
+    return true;
 };

--- a/packages/ra-core/codemods/replace-Datagrid-DataTable.ts
+++ b/packages/ra-core/codemods/replace-Datagrid-DataTable.ts
@@ -214,22 +214,15 @@ const transformChild = (root, j, child) => {
 };
 
 const wrapChild = (j, child) => {
-    const childSource = child.openingElement.attributes.find(
+    const sourceAttribute = child.openingElement.attributes.find(
         attr => j.JSXAttribute.check(attr) && attr.name.name === 'source'
-    )?.value?.value;
+    );
 
     // Wrap the child in a DataTable.Col component
     return j.jsxElement(
         j.jsxOpeningElement(
             j.jsxIdentifier('DataTable.Col'),
-            !childSource
-                ? []
-                : [
-                      j.jsxAttribute(
-                          j.jsxIdentifier('source'),
-                          j.stringLiteral(childSource)
-                      ),
-                  ],
+            !sourceAttribute ? [] : [sourceAttribute],
             false
         ),
         j.jsxClosingElement(j.jsxIdentifier('DataTable.Col')),

--- a/packages/ra-core/codemods/replace-Datagrid-DataTable.ts
+++ b/packages/ra-core/codemods/replace-Datagrid-DataTable.ts
@@ -55,9 +55,36 @@ const replaceImport = (root, j) => {
             node.source
         )
     );
+    return true;
 };
 
 const replaceComponent = (root, j) => {
-    // TODO
+    // Find all instances of Datagrid
+    const datagridComponents = root.find(j.JSXElement, {
+        openingElement: {
+            name: {
+                type: 'JSXIdentifier',
+                name: 'Datagrid',
+            },
+        },
+    });
+
+    if (!datagridComponents.length) {
+        return false;
+    }
+
+    // Replace Datagrid with DataTable
+    datagridComponents.replaceWith(({ node }) => {
+        const openingElement = j.jsxOpeningElement(
+            j.jsxIdentifier('DataTable'),
+            node.openingElement.attributes,
+            node.openingElement.selfClosing
+        );
+        const closingElement = j.jsxClosingElement(
+            j.jsxIdentifier('DataTable')
+        );
+        return j.jsxElement(openingElement, closingElement, node.children);
+    });
+
     return true;
 };

--- a/packages/ra-core/codemods/replace-Datagrid-DataTable.ts
+++ b/packages/ra-core/codemods/replace-Datagrid-DataTable.ts
@@ -214,22 +214,22 @@ const transformChild = (root, j, child) => {
 };
 
 const wrapChild = (j, child) => {
+    const childSource = child.openingElement.attributes.find(
+        attr => j.JSXAttribute.check(attr) && attr.name.name === 'source'
+    )?.value?.value;
+
     // Wrap the child in a DataTable.Col component
     return j.jsxElement(
         j.jsxOpeningElement(
             j.jsxIdentifier('DataTable.Col'),
-            [
-                j.jsxAttribute(
-                    j.jsxIdentifier('source'),
-                    j.stringLiteral(
-                        child.openingElement.attributes.find(
-                            attr =>
-                                j.JSXAttribute.check(attr) &&
-                                attr.name.name === 'source'
-                        )?.value?.value || ''
-                    )
-                ),
-            ],
+            !childSource
+                ? []
+                : [
+                      j.jsxAttribute(
+                          j.jsxIdentifier('source'),
+                          j.stringLiteral(childSource)
+                      ),
+                  ],
             false
         ),
         j.jsxClosingElement(j.jsxIdentifier('DataTable.Col')),

--- a/packages/ra-core/codemods/replace-Datagrid-DataTable.ts
+++ b/packages/ra-core/codemods/replace-Datagrid-DataTable.ts
@@ -9,8 +9,13 @@ module.exports = (file, api: j.API) => {
         return root.toSource();
     }
 
-    const continueAfterComponent = replaceComponent(root, j);
-    if (!continueAfterComponent) {
+    const continueAfterReplaceDatagrid = replaceDatagrid(root, j);
+    if (!continueAfterReplaceDatagrid) {
+        return root.toSource();
+    }
+
+    const continueAfterWrap = wrapChildren(root, j);
+    if (!continueAfterWrap) {
         return root.toSource();
     }
 
@@ -58,7 +63,7 @@ const replaceImport = (root, j) => {
     return true;
 };
 
-const replaceComponent = (root, j) => {
+const replaceDatagrid = (root, j) => {
     // Find all instances of Datagrid
     const datagridComponents = root.find(j.JSXElement, {
         openingElement: {
@@ -87,4 +92,68 @@ const replaceComponent = (root, j) => {
     });
 
     return true;
+};
+
+const wrapChildren = (root, j) => {
+    // Find all instances of Datagrid
+    const datagridComponents = root.find(j.JSXElement, {
+        openingElement: {
+            name: {
+                type: 'JSXIdentifier',
+                name: 'DataTable',
+            },
+        },
+    });
+    if (!datagridComponents.length) {
+        return false;
+    }
+
+    // For each DataTable component, wrap its children in DataTable.Col
+    datagridComponents.forEach(dataTableComponent => {
+        const children = dataTableComponent.value.children.filter(child =>
+            j.JSXElement.check(child)
+        );
+        children.forEach(child => {
+            wrapChild(root, j, child);
+        });
+    });
+};
+
+const wrapChild = (root, j, child) => {
+    // Wrap the child in a DataTable.Col component
+    const wrappedChild = j.jsxElement(
+        j.jsxOpeningElement(
+            j.jsxIdentifier('DataTable.Col'),
+            [
+                j.jsxAttribute(
+                    j.jsxIdentifier('source'),
+                    j.stringLiteral(
+                        child.openingElement.attributes.find(
+                            attr =>
+                                j.JSXAttribute.check(attr) &&
+                                attr.name.name === 'source'
+                        )?.value?.value || ''
+                    )
+                ),
+            ],
+            false
+        ),
+        j.jsxClosingElement(j.jsxIdentifier('DataTable.Col')),
+        [j.jsxText('\n'), child, j.jsxText('\n')]
+    );
+
+    // Replace the original child with the wrapped child
+    root.find(j.JSXElement, {
+        openingElement: {
+            name: {
+                type: 'JSXIdentifier',
+                name: 'DataTable',
+            },
+        },
+    }).forEach(dataTableComponent => {
+        dataTableComponent.value.children =
+            dataTableComponent.value.children.map(c =>
+                c === child ? wrappedChild : c
+            );
+    });
 };

--- a/packages/ra-core/codemods/replace-Datagrid-DataTable.ts
+++ b/packages/ra-core/codemods/replace-Datagrid-DataTable.ts
@@ -84,8 +84,7 @@ const replaceDatagrid = (root, j) => {
 
         const openingElement = j.jsxOpeningElement(
             j.jsxIdentifier('DataTable'),
-            attributes,
-            [node.openingElement.selfClosing]
+            attributes
         );
         const closingElement = j.jsxClosingElement(
             j.jsxIdentifier('DataTable')

--- a/packages/ra-core/codemods/replace-Datagrid-DataTable.ts
+++ b/packages/ra-core/codemods/replace-Datagrid-DataTable.ts
@@ -1,0 +1,52 @@
+import j from 'jscodeshift';
+
+module.exports = (file, api: j.API) => {
+    const j = api.jscodeshift;
+    const root = j(file.source);
+
+    replaceImports(root, j);
+
+    return root.toSource({ quote: 'single', lineTerminator: '\n' });
+};
+
+const replaceImports = (root, j) => {
+    // Check if there is an import from react-admin
+    const reactAdminImport = root.find(j.ImportDeclaration, {
+        source: {
+            value: 'react-admin',
+        },
+    });
+    if (!reactAdminImport.length) {
+        return root.toSource();
+    }
+
+    // Check if there is an import of DataGrid from react-admin
+    const datagridImport = reactAdminImport.filter(path => {
+        return path.node.specifiers.some(
+            specifier =>
+                j.ImportSpecifier.check(specifier) &&
+                specifier.imported.name === 'Datagrid'
+        );
+    });
+    console.log('toto - 4', datagridImport);
+    if (!datagridImport.length) {
+        console.log('toto - 5 - OUT');
+        return root.toSource();
+    }
+
+    // Replace import of DataGrid with DataTable
+    reactAdminImport.replaceWith(({ node }) =>
+        j.importDeclaration(
+            node.specifiers.map(specifier => {
+                if (
+                    j.ImportSpecifier.check(specifier) &&
+                    specifier.imported.name === 'Datagrid'
+                ) {
+                    return j.importSpecifier(j.identifier('DataTable'));
+                }
+                return specifier;
+            }),
+            node.source
+        )
+    );
+};

--- a/packages/ra-core/codemods/replace-Datagrid-DataTable.ts
+++ b/packages/ra-core/codemods/replace-Datagrid-DataTable.ts
@@ -81,10 +81,18 @@ const replaceDatagrid = (root, j) => {
     // Replace Datagrid with DataTable
     datagridComponents.replaceWith(({ node }) => {
         // remove the `optimized` attribute if it exists
-        const attributes = node.openingElement.attributes.filter(
+        const filtredAttributes = node.openingElement.attributes.filter(
             attr =>
                 !(j.JSXAttribute.check(attr) && attr.name.name === 'optimized')
         );
+
+        // rename the `rowStyle` attribute to `rowSx` if it exists
+        const attributes = filtredAttributes.map(attr => {
+            if (j.JSXAttribute.check(attr) && attr.name.name === 'rowStyle') {
+                return j.jsxAttribute(j.jsxIdentifier('rowSx'), attr.value);
+            }
+            return attr;
+        });
 
         const openingElement = j.jsxOpeningElement(
             j.jsxIdentifier('DataTable'),

--- a/packages/ra-core/codemods/replace-Datagrid-DataTable.ts
+++ b/packages/ra-core/codemods/replace-Datagrid-DataTable.ts
@@ -80,24 +80,12 @@ const replaceDatagrid = (root, j) => {
 
     // Replace Datagrid with DataTable
     datagridComponents.replaceWith(({ node }) => {
-        // remove the `optimized` attribute if it exists
-        const filtredAttributes = node.openingElement.attributes.filter(
-            attr =>
-                !(j.JSXAttribute.check(attr) && attr.name.name === 'optimized')
-        );
-
-        // rename the `rowStyle` attribute to `rowSx` if it exists
-        const attributes = filtredAttributes.map(attr => {
-            if (j.JSXAttribute.check(attr) && attr.name.name === 'rowStyle') {
-                return j.jsxAttribute(j.jsxIdentifier('rowSx'), attr.value);
-            }
-            return attr;
-        });
+        const attributes = cleanAttributes(node, j);
 
         const openingElement = j.jsxOpeningElement(
             j.jsxIdentifier('DataTable'),
             attributes,
-            node.openingElement.selfClosing
+            [node.openingElement.selfClosing]
         );
         const closingElement = j.jsxClosingElement(
             j.jsxIdentifier('DataTable')
@@ -106,6 +94,55 @@ const replaceDatagrid = (root, j) => {
     });
 
     return true;
+};
+
+const cleanAttributes = (node, j) => {
+    // remove the `optimized` attribute if it exists
+    const filtredAttributes = node.openingElement.attributes.filter(
+        attr => !(j.JSXAttribute.check(attr) && attr.name.name === 'optimized')
+    );
+
+    // rename the `rowStyle` attribute to `rowSx` if it exists
+    const rowSxRenamedAttributes = filtredAttributes.map(attr => {
+        if (j.JSXAttribute.check(attr) && attr.name.name === 'rowStyle') {
+            return j.jsxAttribute(j.jsxIdentifier('rowSx'), attr.value);
+        }
+        return attr;
+    });
+
+    // rename the keys of the "sx" prop from "& .RaDatagrid-xxxx" to "& .RaDataTable-xxxx"
+    const sxRenamedAttributes = rowSxRenamedAttributes.map(attr => {
+        if (
+            j.JSXAttribute.check(attr) &&
+            attr.name.name === 'sx' &&
+            j.JSXExpressionContainer.check(attr.value)
+        ) {
+            const expression = attr.value.expression;
+            if (j.ObjectExpression.check(expression)) {
+                const properties = expression.properties.map(prop => {
+                    if (
+                        j.ObjectProperty.check(prop) &&
+                        j.Literal.check(prop.key) &&
+                        typeof prop.key.value === 'string'
+                    ) {
+                        const newKey = prop.key.value.replace(
+                            /RaDatagrid-/g,
+                            'RaDataTable-'
+                        );
+                        return j.objectProperty(j.literal(newKey), prop.value);
+                    }
+                    return prop;
+                });
+                return j.jsxAttribute(
+                    j.jsxIdentifier('sx'),
+                    j.jsxExpressionContainer(j.objectExpression(properties))
+                );
+            }
+        }
+        return attr;
+    });
+
+    return sxRenamedAttributes;
 };
 
 const wrapChildren = (root, j) => {


### PR DESCRIPTION
# PR Summary

Add Codemod for Migrating from Datagrid to DataTable

## Overview

This PR adds a new codemod script and corresponding tests to facilitate the migration from Datagrid to DataTable components in React Admin applications.

## Change Types

| Type         | Description                            |
|--------------|----------------------------------------|
| Feature      | New codemod script for Datagrid to DataTable migration |
| Test         | Test cases for the new codemod functionality |

---

## Affected Modules

| Module / File          | Change Description                       |
|------------------------|------------------------------------------|
| `ra-core/codemods/replace-Datagrid-DataTable.ts` | New codemod script for transforming Datagrid components to DataTable |
| `ra-core/codemods/__tests__/replace-Datagrid-DataTable.spec.ts` | Test cases for the Datagrid to DataTable codemod |

---

## Notes for Reviewers

* The codemod handles import replacements, component transformations, and attribute handling
* Verify that all common Datagrid usage patterns are properly transformed